### PR TITLE
Specify timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
 before_script:
   - 'git clone git://github.com/gini/puppet-archive.git spec/fixtures/modules/archive'
 env:
-  - PUPPET_VERSION=2.6.2
-  - PUPPET_VERSION=2.6.18
-  - PUPPET_VERSION=2.7.21
   - PUPPET_VERSION=3.0.2
   - PUPPET_VERSION=3.1.1
   - PUPPET_VERSION=3.2.1

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -21,6 +21,9 @@
 #   Specify the location of the symlink to the IntelliJ IDEA installation on
 #   the local filesystem.
 #
+# [*timeout*]
+#   Download timeout passed to archive module.
+#
 # === Variables
 #
 # The variables being used by this module are named exactly like the class
@@ -39,6 +42,7 @@ class idea::base(
   $url,
   $build,
   $target,
+  $timeout,
 ) {
 
   Exec {
@@ -57,6 +61,7 @@ class idea::base(
     src_target => '/var/tmp',
     target     => '/opt',
     extension  => 'tar.gz',
+    timeout    => $timeout,
   }
 
   file { $target:

--- a/manifests/community.pp
+++ b/manifests/community.pp
@@ -25,6 +25,9 @@
 #   Specify the location of the symlink to the IntelliJ IDEA installation on
 #   the local filesystem.
 #
+# [*timeout*]
+#   Download timeout passed to archive module.
+#
 # === Variables
 #
 # The variables being used by this module are named exactly like the class
@@ -51,6 +54,7 @@ class idea::community(
   $url      = 'UNSET',
   $build    = 'UNSET',
   $target   = 'UNSET',
+  $timeout  = 'UNSET',
 ) {
 
   include idea::params
@@ -75,6 +79,11 @@ class idea::community(
     default => $target,
   }
 
+  $timeout_real = $timeout ? {
+    'UNSET' => $::idea::params::timeout,
+    default => $timeout,
+  }
+
   $build_real = $build ? {
     'UNSET' => $::idea::params::build,
     default => $build,
@@ -87,5 +96,6 @@ class idea::community(
     url     => $url_real,
     build   => $community_build,
     target  => $target_real,
+    timeout => $timeout_real,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,9 @@
 #   Specify the location of the symlink to the IntelliJ IDEA installation on
 #   the local filesystem.
 #
+# [*timeout*]
+#   Download timeout passed to archive module.
+#
 # === Variables
 #
 # The variables being used by this module are named exactly like the class
@@ -46,11 +49,13 @@ class idea(
   $url      = 'UNSET',
   $build    = 'UNSET',
   $target   = 'UNSET',
+  $timeout  = 'UNSET',
 ) {
   class { 'idea::community':
     version => $version,
     url     => $url,
     build   => $build,
     target  => $target,
+    timeout => $timeout,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,4 +48,9 @@ class idea::params {
     undef   => '/opt/idea',
     default => $::idea_target,
   }
+
+  $timeout = $::idea_timeout ? {
+    undef   => 300,
+    default => $::idea_timeout,
+  }
 }


### PR DESCRIPTION
120s can be challenging on a slow connection. New reasonable default set to 5 minutes and introduced new parameter  timeout.
